### PR TITLE
Fixes #12: Trim the output html to fix support in mdx

### DIFF
--- a/specs/__snapshots__/index.specs.js.snap
+++ b/specs/__snapshots__/index.specs.js.snap
@@ -162,8 +162,7 @@ Object {
         hosted with &#10084; by <a href=\\"https://github.com\\">GitHub</a>
       </div>
     </div>
-</div>
-",
+</div>",
 }
 `;
 
@@ -211,8 +210,7 @@ Object {
         hosted with &#10084; by <a href=\\"https://github.com\\">GitHub</a>
       </div>
     </div>
-</div>
-",
+</div>",
 }
 `;
 
@@ -260,8 +258,7 @@ Object {
         hosted with &#10084; by <a href=\\"https://github.com\\">GitHub</a>
       </div>
     </div>
-</div>
-",
+</div>",
 }
 `;
 
@@ -1203,8 +1200,7 @@ Object {
         hosted with &#10084; by <a href=\\"https://github.com\\">GitHub</a>
       </div>
     </div>
-</div>
-",
+</div>",
 }
 `;
 
@@ -1252,8 +1248,7 @@ Object {
         hosted with &#10084; by <a href=\\"https://github.com\\">GitHub</a>
       </div>
     </div>
-</div>
-",
+</div>",
 }
 `;
 
@@ -1301,8 +1296,7 @@ Object {
         hosted with &#10084; by <a href=\\"https://github.com\\">GitHub</a>
       </div>
     </div>
-</div>
-",
+</div>",
 }
 `;
 
@@ -2244,8 +2238,7 @@ Object {
         hosted with &#10084; by <a href=\\"https://github.com\\">GitHub</a>
       </div>
     </div>
-</div>
-",
+</div>",
 }
 `;
 
@@ -2293,8 +2286,7 @@ Object {
         hosted with &#10084; by <a href=\\"https://github.com\\">GitHub</a>
       </div>
     </div>
-</div>
-",
+</div>",
 }
 `;
 
@@ -2342,8 +2334,7 @@ Object {
         hosted with &#10084; by <a href=\\"https://github.com\\">GitHub</a>
       </div>
     </div>
-</div>
-",
+</div>",
 }
 `;
 

--- a/src/index.js
+++ b/src/index.js
@@ -113,9 +113,9 @@ function buildUrl(value, options, file) {
 export default async ({ markdownAST }, options = {}) => {
   // this returns a promise that will fulfill immediately for everything
   // that is not an inlineCode that starts with `gist:`
-  return await visit(markdownAST, async node => {
+  return await visit(markdownAST, "inlineCode", async node => {
     // validate pre-requisites.
-    if (node.type !== "inlineCode" || !node.value.startsWith("gist:")) return;
+    if (!node.value.startsWith("gist:")) return;
 
     // get the query string and build the url
     const query = getQuery(node.value.substring(5));
@@ -138,7 +138,7 @@ export default async ({ markdownAST }, options = {}) => {
     }
 
     node.type = "html";
-    node.value = html;
+    node.value = html.trim();
 
     return markdownAST;
   });


### PR DESCRIPTION
TLDR - the gist html comes with a trailing break that need to be removed.

Explanation - the trailing break in the html is interpreted by mdx as a separate node. This generates a raw element with multiple nodes that mdx interpretes as a root element... 

https://github.com/mdx-js/mdx/blob/650afefb59ff21c3b6bbd0db8f854e772d97bf70/packages/mdx/index.js#L84-L93

Then

https://github.com/syntax-tree/hast-util-raw/blob/dd17f29756ad82b00784515a450590205299b1e2/index.js#L44-L51

Finally, when the tree is converted to jsx via the toJSX method defined [here](https://github.com/mdx-js/mdx/blob/master/packages/mdx/mdx-hast-to-jsx.js), each root elements outputs the exact same react component structure which causes a nasty nesting of components...