### PR TITLE
feature: add parameter to select specific lines from gist

### DIFF
--- a/specs/__snapshots__/index.specs.js.snap
+++ b/specs/__snapshots__/index.specs.js.snap
@@ -456,6 +456,174 @@ Object {
 }
 `;
 
+exports[`gatsby-remark-embedded-gist generates an embedded gist with default username and file in query with mixed lines highlighted and selected 1`] = `
+Object {
+  "position": Position {
+    "end": Object {
+      "column": 97,
+      "line": 1,
+      "offset": 96,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "html",
+  "value": "<html><head></head><body><div id=\\"gist90436059\\" class=\\"gist\\">
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-2016-08-31-stream-redirection\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-2016-08-31-stream-redirection-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-2016-08-31-stream-redirection-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">2016.08.31.stream-redirection</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/.2016.08.31.stream-redirection\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-2016-08-31-stream-redirection\\">.2016.08.31.stream-redirection</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-example-sh\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-shell\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-example-sh-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-example-sh-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> no redirection</span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L2\\" class=\\"blob-num js-line-number\\" data-line-number=\\"2\\"></td>
+        <td id=\\"file-example-sh-LC2\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L3\\" class=\\"blob-num js-line-number\\" data-line-number=\\"3\\"></td>
+        <td id=\\"file-example-sh-LC3\\" class=\\"blob-code blob-code-inner js-file-line\\">  hello</td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L4\\" class=\\"blob-num js-line-number\\" data-line-number=\\"4\\"></td>
+        <td id=\\"file-example-sh-LC4\\" class=\\"blob-code blob-code-inner js-file-line\\">  </td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L5\\" class=\\"blob-num js-line-number\\" data-line-number=\\"5\\"></td>
+        <td id=\\"file-example-sh-LC5\\" class=\\"blob-code blob-code-inner js-file-line\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> redirects standard error (no error in this case)</span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L6\\" class=\\"blob-num js-line-number\\" data-line-number=\\"6\\"></td>
+        <td id=\\"file-example-sh-LC6\\" class=\\"blob-code blob-code-inner js-file-line\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span> <span class=\\"pl-k\\">2&gt;</span> /dev/null</td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L7\\" class=\\"blob-num js-line-number\\" data-line-number=\\"7\\"></td>
+        <td id=\\"file-example-sh-LC7\\" class=\\"blob-code blob-code-inner js-file-line\\">  hello</td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L8\\" class=\\"blob-num js-line-number\\" data-line-number=\\"8\\"></td>
+        <td id=\\"file-example-sh-LC8\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">  </td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L9\\" class=\\"blob-num js-line-number\\" data-line-number=\\"9\\"></td>
+        <td id=\\"file-example-sh-LC9\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> redirects standard out to /dev/null (so no output) </span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L10\\" class=\\"blob-num js-line-number\\" data-line-number=\\"10\\"></td>
+        <td id=\\"file-example-sh-LC10\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span> <span class=\\"pl-k\\">1&gt;</span> /dev/null </td>
+      </tr>
+      
+      <tr>
+        <td id=\\"file-example-sh-L12\\" class=\\"blob-num js-line-number\\" data-line-number=\\"12\\"></td>
+        <td id=\\"file-example-sh-LC12\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> redirects everything to /dev/null (so no output)</span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L13\\" class=\\"blob-num js-line-number\\" data-line-number=\\"13\\"></td>
+        <td id=\\"file-example-sh-LC13\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span> <span class=\\"pl-k\\">&amp;</span><span class=\\"pl-k\\">&gt;</span> /dev/null </td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L14\\" class=\\"blob-num js-line-number\\" data-line-number=\\"14\\"></td>
+        <td id=\\"file-example-sh-LC14\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">
+</td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L15\\" class=\\"blob-num js-line-number\\" data-line-number=\\"15\\"></td>
+        <td id=\\"file-example-sh-LC15\\" class=\\"blob-code blob-code-inner js-file-line\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> no redirection (causing error)    </span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L16\\" class=\\"blob-num js-line-number\\" data-line-number=\\"16\\"></td>
+        <td id=\\"file-example-sh-LC16\\" class=\\"blob-code blob-code-inner js-file-line\\">$ unlink unexisting-file.sh </td>
+      </tr>
+      
+      
+      
+      
+      
+      
+      
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/example.sh\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-example-sh\\">example.sh</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-syntax-text\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-syntax-text-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-syntax-text-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">&lt;operation&gt; [n]&gt; /dev/null [options]</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/syntax.text\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-syntax-text\\">syntax.text</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+</div>
+</body></html>",
+}
+`;
+
 exports[`gatsby-remark-embedded-gist generates an embedded gist with default username and file in query with muplie lines highlighted 1`] = `
 Object {
   "position": Position {
@@ -650,6 +818,146 @@ Object {
 }
 `;
 
+exports[`gatsby-remark-embedded-gist generates an embedded gist with default username and file in query with muplie lines highlighted and multiple lines selected 1`] = `
+Object {
+  "position": Position {
+    "end": Object {
+      "column": 85,
+      "line": 1,
+      "offset": 84,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "html",
+  "value": "<html><head></head><body><div id=\\"gist90436059\\" class=\\"gist\\">
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-2016-08-31-stream-redirection\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-2016-08-31-stream-redirection-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-2016-08-31-stream-redirection-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">2016.08.31.stream-redirection</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/.2016.08.31.stream-redirection\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-2016-08-31-stream-redirection\\">.2016.08.31.stream-redirection</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-example-sh\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-shell\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-example-sh-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-example-sh-LC1\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> no redirection</span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L2\\" class=\\"blob-num js-line-number\\" data-line-number=\\"2\\"></td>
+        <td id=\\"file-example-sh-LC2\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L3\\" class=\\"blob-num js-line-number\\" data-line-number=\\"3\\"></td>
+        <td id=\\"file-example-sh-LC3\\" class=\\"blob-code blob-code-inner js-file-line\\">  hello</td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L4\\" class=\\"blob-num js-line-number\\" data-line-number=\\"4\\"></td>
+        <td id=\\"file-example-sh-LC4\\" class=\\"blob-code blob-code-inner js-file-line\\">  </td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L5\\" class=\\"blob-num js-line-number\\" data-line-number=\\"5\\"></td>
+        <td id=\\"file-example-sh-LC5\\" class=\\"blob-code blob-code-inner js-file-line\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> redirects standard error (no error in this case)</span></td>
+      </tr>
+      
+      
+      <tr>
+        <td id=\\"file-example-sh-L8\\" class=\\"blob-num js-line-number\\" data-line-number=\\"8\\"></td>
+        <td id=\\"file-example-sh-LC8\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">  </td>
+      </tr>
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/example.sh\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-example-sh\\">example.sh</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-syntax-text\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-syntax-text-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-syntax-text-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">&lt;operation&gt; [n]&gt; /dev/null [options]</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/syntax.text\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-syntax-text\\">syntax.text</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+</div>
+</body></html>",
+}
+`;
+
 exports[`gatsby-remark-embedded-gist generates an embedded gist with default username and file in query with range of lines highlighted 1`] = `
 Object {
   "position": Position {
@@ -797,6 +1105,146 @@ Object {
         <td id=\\"file-example-sh-L23\\" class=\\"blob-num js-line-number\\" data-line-number=\\"23\\"></td>
         <td id=\\"file-example-sh-LC23\\" class=\\"blob-code blob-code-inner js-file-line\\">$ unlink unexisting-file.sh <span class=\\"pl-k\\">&amp;</span><span class=\\"pl-k\\">&gt;</span> /dev/null</td>
       </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/example.sh\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-example-sh\\">example.sh</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-syntax-text\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-syntax-text-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-syntax-text-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">&lt;operation&gt; [n]&gt; /dev/null [options]</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/syntax.text\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-syntax-text\\">syntax.text</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+</div>
+</body></html>",
+}
+`;
+
+exports[`gatsby-remark-embedded-gist generates an embedded gist with default username and file in query with range of lines highlighted and range of lines selected 1`] = `
+Object {
+  "position": Position {
+    "end": Object {
+      "column": 81,
+      "line": 1,
+      "offset": 80,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "html",
+  "value": "<html><head></head><body><div id=\\"gist90436059\\" class=\\"gist\\">
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-2016-08-31-stream-redirection\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-2016-08-31-stream-redirection-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-2016-08-31-stream-redirection-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">2016.08.31.stream-redirection</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/.2016.08.31.stream-redirection\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-2016-08-31-stream-redirection\\">.2016.08.31.stream-redirection</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-example-sh\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-shell\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody>
+      <tr>
+        <td id=\\"file-example-sh-L2\\" class=\\"blob-num js-line-number\\" data-line-number=\\"2\\"></td>
+        <td id=\\"file-example-sh-LC2\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L3\\" class=\\"blob-num js-line-number\\" data-line-number=\\"3\\"></td>
+        <td id=\\"file-example-sh-LC3\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">  hello</td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L4\\" class=\\"blob-num js-line-number\\" data-line-number=\\"4\\"></td>
+        <td id=\\"file-example-sh-LC4\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">  </td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L5\\" class=\\"blob-num js-line-number\\" data-line-number=\\"5\\"></td>
+        <td id=\\"file-example-sh-LC5\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> redirects standard error (no error in this case)</span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L6\\" class=\\"blob-num js-line-number\\" data-line-number=\\"6\\"></td>
+        <td id=\\"file-example-sh-LC6\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span> <span class=\\"pl-k\\">2&gt;</span> /dev/null</td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L7\\" class=\\"blob-num js-line-number\\" data-line-number=\\"7\\"></td>
+        <td id=\\"file-example-sh-LC7\\" class=\\"blob-code blob-code-inner js-file-line\\">  hello</td>
+      </tr>
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
 </tbody></table>
 
 
@@ -1494,6 +1942,146 @@ Object {
 }
 `;
 
+exports[`gatsby-remark-embedded-gist generates an embedded gist with username and file in query with mixed lines highlighted and mixed lines selected 1`] = `
+Object {
+  "position": Position {
+    "end": Object {
+      "column": 98,
+      "line": 1,
+      "offset": 97,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "html",
+  "value": "<html><head></head><body><div id=\\"gist90436059\\" class=\\"gist\\">
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-2016-08-31-stream-redirection\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-2016-08-31-stream-redirection-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-2016-08-31-stream-redirection-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">2016.08.31.stream-redirection</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/.2016.08.31.stream-redirection\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-2016-08-31-stream-redirection\\">.2016.08.31.stream-redirection</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-example-sh\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-shell\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-example-sh-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-example-sh-LC1\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> no redirection</span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L2\\" class=\\"blob-num js-line-number\\" data-line-number=\\"2\\"></td>
+        <td id=\\"file-example-sh-LC2\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L3\\" class=\\"blob-num js-line-number\\" data-line-number=\\"3\\"></td>
+        <td id=\\"file-example-sh-LC3\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">  hello</td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L4\\" class=\\"blob-num js-line-number\\" data-line-number=\\"4\\"></td>
+        <td id=\\"file-example-sh-LC4\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">  </td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L5\\" class=\\"blob-num js-line-number\\" data-line-number=\\"5\\"></td>
+        <td id=\\"file-example-sh-LC5\\" class=\\"blob-code blob-code-inner js-file-line\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> redirects standard error (no error in this case)</span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L6\\" class=\\"blob-num js-line-number\\" data-line-number=\\"6\\"></td>
+        <td id=\\"file-example-sh-LC6\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span> <span class=\\"pl-k\\">2&gt;</span> /dev/null</td>
+      </tr>
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/example.sh\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-example-sh\\">example.sh</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-syntax-text\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-syntax-text-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-syntax-text-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">&lt;operation&gt; [n]&gt; /dev/null [options]</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/syntax.text\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-syntax-text\\">syntax.text</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+</div>
+</body></html>",
+}
+`;
+
 exports[`gatsby-remark-embedded-gist generates an embedded gist with username and file in query with multiple lines highlighted 1`] = `
 Object {
   "position": Position {
@@ -1641,6 +2229,146 @@ Object {
         <td id=\\"file-example-sh-L23\\" class=\\"blob-num js-line-number\\" data-line-number=\\"23\\"></td>
         <td id=\\"file-example-sh-LC23\\" class=\\"blob-code blob-code-inner js-file-line\\">$ unlink unexisting-file.sh <span class=\\"pl-k\\">&amp;</span><span class=\\"pl-k\\">&gt;</span> /dev/null</td>
       </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/example.sh\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-example-sh\\">example.sh</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-syntax-text\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-syntax-text-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-syntax-text-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">&lt;operation&gt; [n]&gt; /dev/null [options]</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/syntax.text\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-syntax-text\\">syntax.text</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+</div>
+</body></html>",
+}
+`;
+
+exports[`gatsby-remark-embedded-gist generates an embedded gist with username and file in query with multiple lines highlighted and multiple lines selected 1`] = `
+Object {
+  "position": Position {
+    "end": Object {
+      "column": 104,
+      "line": 1,
+      "offset": 103,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "html",
+  "value": "<html><head></head><body><div id=\\"gist90436059\\" class=\\"gist\\">
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-2016-08-31-stream-redirection\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-2016-08-31-stream-redirection-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-2016-08-31-stream-redirection-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">2016.08.31.stream-redirection</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/.2016.08.31.stream-redirection\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-2016-08-31-stream-redirection\\">.2016.08.31.stream-redirection</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-example-sh\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-shell\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-example-sh-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-example-sh-LC1\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> no redirection</span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L2\\" class=\\"blob-num js-line-number\\" data-line-number=\\"2\\"></td>
+        <td id=\\"file-example-sh-LC2\\" class=\\"blob-code blob-code-inner js-file-line\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L3\\" class=\\"blob-num js-line-number\\" data-line-number=\\"3\\"></td>
+        <td id=\\"file-example-sh-LC3\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">  hello</td>
+      </tr>
+      
+      <tr>
+        <td id=\\"file-example-sh-L5\\" class=\\"blob-num js-line-number\\" data-line-number=\\"5\\"></td>
+        <td id=\\"file-example-sh-LC5\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> redirects standard error (no error in this case)</span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L6\\" class=\\"blob-num js-line-number\\" data-line-number=\\"6\\"></td>
+        <td id=\\"file-example-sh-LC6\\" class=\\"blob-code blob-code-inner js-file-line\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span> <span class=\\"pl-k\\">2&gt;</span> /dev/null</td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L7\\" class=\\"blob-num js-line-number\\" data-line-number=\\"7\\"></td>
+        <td id=\\"file-example-sh-LC7\\" class=\\"blob-code blob-code-inner js-file-line\\">  hello</td>
+      </tr>
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
 </tbody></table>
 
 
@@ -1882,6 +2610,146 @@ Object {
 }
 `;
 
+exports[`gatsby-remark-embedded-gist generates an embedded gist with username and file in query with range of lines highlighted and selected 1`] = `
+Object {
+  "position": Position {
+    "end": Object {
+      "column": 94,
+      "line": 1,
+      "offset": 93,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "html",
+  "value": "<html><head></head><body><div id=\\"gist90436059\\" class=\\"gist\\">
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-2016-08-31-stream-redirection\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-2016-08-31-stream-redirection-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-2016-08-31-stream-redirection-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">2016.08.31.stream-redirection</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/.2016.08.31.stream-redirection\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-2016-08-31-stream-redirection\\">.2016.08.31.stream-redirection</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-example-sh\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-shell\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-example-sh-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-example-sh-LC1\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> no redirection</span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L2\\" class=\\"blob-num js-line-number\\" data-line-number=\\"2\\"></td>
+        <td id=\\"file-example-sh-LC2\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L3\\" class=\\"blob-num js-line-number\\" data-line-number=\\"3\\"></td>
+        <td id=\\"file-example-sh-LC3\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">  hello</td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L4\\" class=\\"blob-num js-line-number\\" data-line-number=\\"4\\"></td>
+        <td id=\\"file-example-sh-LC4\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">  </td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L5\\" class=\\"blob-num js-line-number\\" data-line-number=\\"5\\"></td>
+        <td id=\\"file-example-sh-LC5\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> redirects standard error (no error in this case)</span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L6\\" class=\\"blob-num js-line-number\\" data-line-number=\\"6\\"></td>
+        <td id=\\"file-example-sh-LC6\\" class=\\"blob-code blob-code-inner js-file-line\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span> <span class=\\"pl-k\\">2&gt;</span> /dev/null</td>
+      </tr>
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/example.sh\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-example-sh\\">example.sh</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-syntax-text\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-syntax-text-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-syntax-text-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">&lt;operation&gt; [n]&gt; /dev/null [options]</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/syntax.text\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-syntax-text\\">syntax.text</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+</div>
+</body></html>",
+}
+`;
+
 exports[`gatsby-remark-embedded-gist generates an embedded gist with username and file in query with single line highlighted 1`] = `
 Object {
   "position": Position {
@@ -2029,6 +2897,131 @@ Object {
         <td id=\\"file-example-sh-L23\\" class=\\"blob-num js-line-number\\" data-line-number=\\"23\\"></td>
         <td id=\\"file-example-sh-LC23\\" class=\\"blob-code blob-code-inner js-file-line\\">$ unlink unexisting-file.sh <span class=\\"pl-k\\">&amp;</span><span class=\\"pl-k\\">&gt;</span> /dev/null</td>
       </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/example.sh\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-example-sh\\">example.sh</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-syntax-text\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-syntax-text-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-syntax-text-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">&lt;operation&gt; [n]&gt; /dev/null [options]</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/syntax.text\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-syntax-text\\">syntax.text</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+</div>
+</body></html>",
+}
+`;
+
+exports[`gatsby-remark-embedded-gist generates an embedded gist with username and file in query with single line highlighted and single line selected 1`] = `
+Object {
+  "position": Position {
+    "end": Object {
+      "column": 90,
+      "line": 1,
+      "offset": 89,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "html",
+  "value": "<html><head></head><body><div id=\\"gist90436059\\" class=\\"gist\\">
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-2016-08-31-stream-redirection\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-2016-08-31-stream-redirection-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-2016-08-31-stream-redirection-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">2016.08.31.stream-redirection</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/.2016.08.31.stream-redirection\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-2016-08-31-stream-redirection\\">.2016.08.31.stream-redirection</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-example-sh\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-shell\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-example-sh-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-example-sh-LC1\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> no redirection</span></td>
+      </tr>
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
 </tbody></table>
 
 
@@ -2532,6 +3525,158 @@ Object {
 }
 `;
 
+exports[`gatsby-remark-embedded-gist inline username overrides configuration with file in query with mixed lines highlighted and selected 1`] = `
+Object {
+  "position": Position {
+    "end": Object {
+      "column": 114,
+      "line": 1,
+      "offset": 113,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "html",
+  "value": "<html><head></head><body><div id=\\"gist90436059\\" class=\\"gist\\">
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-2016-08-31-stream-redirection\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-2016-08-31-stream-redirection-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-2016-08-31-stream-redirection-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">2016.08.31.stream-redirection</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/.2016.08.31.stream-redirection\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-2016-08-31-stream-redirection\\">.2016.08.31.stream-redirection</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-example-sh\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-shell\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-example-sh-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-example-sh-LC1\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> no redirection</span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L2\\" class=\\"blob-num js-line-number\\" data-line-number=\\"2\\"></td>
+        <td id=\\"file-example-sh-LC2\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L3\\" class=\\"blob-num js-line-number\\" data-line-number=\\"3\\"></td>
+        <td id=\\"file-example-sh-LC3\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">  hello</td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L4\\" class=\\"blob-num js-line-number\\" data-line-number=\\"4\\"></td>
+        <td id=\\"file-example-sh-LC4\\" class=\\"blob-code blob-code-inner js-file-line\\">  </td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L5\\" class=\\"blob-num js-line-number\\" data-line-number=\\"5\\"></td>
+        <td id=\\"file-example-sh-LC5\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> redirects standard error (no error in this case)</span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L6\\" class=\\"blob-num js-line-number\\" data-line-number=\\"6\\"></td>
+        <td id=\\"file-example-sh-LC6\\" class=\\"blob-code blob-code-inner js-file-line\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span> <span class=\\"pl-k\\">2&gt;</span> /dev/null</td>
+      </tr>
+      
+      
+      
+      <tr>
+        <td id=\\"file-example-sh-L10\\" class=\\"blob-num js-line-number\\" data-line-number=\\"10\\"></td>
+        <td id=\\"file-example-sh-LC10\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span> <span class=\\"pl-k\\">1&gt;</span> /dev/null </td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L11\\" class=\\"blob-num js-line-number\\" data-line-number=\\"11\\"></td>
+        <td id=\\"file-example-sh-LC11\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">  </td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L12\\" class=\\"blob-num js-line-number\\" data-line-number=\\"12\\"></td>
+        <td id=\\"file-example-sh-LC12\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> redirects everything to /dev/null (so no output)</span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L13\\" class=\\"blob-num js-line-number\\" data-line-number=\\"13\\"></td>
+        <td id=\\"file-example-sh-LC13\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span> <span class=\\"pl-k\\">&amp;</span><span class=\\"pl-k\\">&gt;</span> /dev/null </td>
+      </tr>
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/example.sh\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-example-sh\\">example.sh</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-syntax-text\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-syntax-text-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-syntax-text-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">&lt;operation&gt; [n]&gt; /dev/null [options]</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/syntax.text\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-syntax-text\\">syntax.text</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+</div>
+</body></html>",
+}
+`;
+
 exports[`gatsby-remark-embedded-gist inline username overrides configuration with file in query with multiple lines highlighted 1`] = `
 Object {
   "position": Position {
@@ -2679,6 +3824,143 @@ Object {
         <td id=\\"file-example-sh-L23\\" class=\\"blob-num js-line-number\\" data-line-number=\\"23\\"></td>
         <td id=\\"file-example-sh-LC23\\" class=\\"blob-code blob-code-inner js-file-line\\">$ unlink unexisting-file.sh <span class=\\"pl-k\\">&amp;</span><span class=\\"pl-k\\">&gt;</span> /dev/null</td>
       </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/example.sh\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-example-sh\\">example.sh</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-syntax-text\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-syntax-text-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-syntax-text-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">&lt;operation&gt; [n]&gt; /dev/null [options]</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/syntax.text\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-syntax-text\\">syntax.text</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+</div>
+</body></html>",
+}
+`;
+
+exports[`gatsby-remark-embedded-gist inline username overrides configuration with file in query with multiple lines highlighted and multiple lines selected 1`] = `
+Object {
+  "position": Position {
+    "end": Object {
+      "column": 103,
+      "line": 1,
+      "offset": 102,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "html",
+  "value": "<html><head></head><body><div id=\\"gist90436059\\" class=\\"gist\\">
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-2016-08-31-stream-redirection\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-2016-08-31-stream-redirection-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-2016-08-31-stream-redirection-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">2016.08.31.stream-redirection</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/.2016.08.31.stream-redirection\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-2016-08-31-stream-redirection\\">.2016.08.31.stream-redirection</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-example-sh\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-shell\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-example-sh-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-example-sh-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> no redirection</span></td>
+      </tr>
+      
+      
+      
+      <tr>
+        <td id=\\"file-example-sh-L5\\" class=\\"blob-num js-line-number\\" data-line-number=\\"5\\"></td>
+        <td id=\\"file-example-sh-LC5\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> redirects standard error (no error in this case)</span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L6\\" class=\\"blob-num js-line-number\\" data-line-number=\\"6\\"></td>
+        <td id=\\"file-example-sh-LC6\\" class=\\"blob-code blob-code-inner js-file-line\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span> <span class=\\"pl-k\\">2&gt;</span> /dev/null</td>
+      </tr>
+      
+      
+      
+      <tr>
+        <td id=\\"file-example-sh-L10\\" class=\\"blob-num js-line-number\\" data-line-number=\\"10\\"></td>
+        <td id=\\"file-example-sh-LC10\\" class=\\"blob-code blob-code-inner js-file-line\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span> <span class=\\"pl-k\\">1&gt;</span> /dev/null </td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L11\\" class=\\"blob-num js-line-number\\" data-line-number=\\"11\\"></td>
+        <td id=\\"file-example-sh-LC11\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">  </td>
+      </tr>
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
 </tbody></table>
 
 
@@ -2920,6 +4202,165 @@ Object {
 }
 `;
 
+exports[`gatsby-remark-embedded-gist inline username overrides configuration with file in query with range of lines highlighted and range of lines selected 1`] = `
+Object {
+  "position": Position {
+    "end": Object {
+      "column": 96,
+      "line": 1,
+      "offset": 95,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "html",
+  "value": "<html><head></head><body><div id=\\"gist90436059\\" class=\\"gist\\">
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-2016-08-31-stream-redirection\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-2016-08-31-stream-redirection-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-2016-08-31-stream-redirection-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">2016.08.31.stream-redirection</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/.2016.08.31.stream-redirection\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-2016-08-31-stream-redirection\\">.2016.08.31.stream-redirection</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-example-sh\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-shell\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody>
+      
+      
+      <tr>
+        <td id=\\"file-example-sh-L4\\" class=\\"blob-num js-line-number\\" data-line-number=\\"4\\"></td>
+        <td id=\\"file-example-sh-LC4\\" class=\\"blob-code blob-code-inner js-file-line\\">  </td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L5\\" class=\\"blob-num js-line-number\\" data-line-number=\\"5\\"></td>
+        <td id=\\"file-example-sh-LC5\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> redirects standard error (no error in this case)</span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L6\\" class=\\"blob-num js-line-number\\" data-line-number=\\"6\\"></td>
+        <td id=\\"file-example-sh-LC6\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span> <span class=\\"pl-k\\">2&gt;</span> /dev/null</td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L7\\" class=\\"blob-num js-line-number\\" data-line-number=\\"7\\"></td>
+        <td id=\\"file-example-sh-LC7\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">  hello</td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L8\\" class=\\"blob-num js-line-number\\" data-line-number=\\"8\\"></td>
+        <td id=\\"file-example-sh-LC8\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">  </td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L9\\" class=\\"blob-num js-line-number\\" data-line-number=\\"9\\"></td>
+        <td id=\\"file-example-sh-LC9\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> redirects standard out to /dev/null (so no output) </span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L10\\" class=\\"blob-num js-line-number\\" data-line-number=\\"10\\"></td>
+        <td id=\\"file-example-sh-LC10\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span> <span class=\\"pl-k\\">1&gt;</span> /dev/null </td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L11\\" class=\\"blob-num js-line-number\\" data-line-number=\\"11\\"></td>
+        <td id=\\"file-example-sh-LC11\\" class=\\"blob-code blob-code-inner js-file-line\\">  </td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L12\\" class=\\"blob-num js-line-number\\" data-line-number=\\"12\\"></td>
+        <td id=\\"file-example-sh-LC12\\" class=\\"blob-code blob-code-inner js-file-line\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> redirects everything to /dev/null (so no output)</span></td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L13\\" class=\\"blob-num js-line-number\\" data-line-number=\\"13\\"></td>
+        <td id=\\"file-example-sh-LC13\\" class=\\"blob-code blob-code-inner js-file-line\\">$ <span class=\\"pl-c1\\">echo</span> <span class=\\"pl-s\\"><span class=\\"pl-pds\\">&apos;</span>hello<span class=\\"pl-pds\\">&apos;</span></span> <span class=\\"pl-k\\">&amp;</span><span class=\\"pl-k\\">&gt;</span> /dev/null </td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L14\\" class=\\"blob-num js-line-number\\" data-line-number=\\"14\\"></td>
+        <td id=\\"file-example-sh-LC14\\" class=\\"blob-code blob-code-inner js-file-line\\">
+</td>
+      </tr>
+      <tr>
+        <td id=\\"file-example-sh-L15\\" class=\\"blob-num js-line-number\\" data-line-number=\\"15\\"></td>
+        <td id=\\"file-example-sh-LC15\\" class=\\"blob-code blob-code-inner js-file-line\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> no redirection (causing error)    </span></td>
+      </tr>
+      
+      
+      
+      
+      
+      
+      
+      
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/example.sh\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-example-sh\\">example.sh</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-syntax-text\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-syntax-text-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-syntax-text-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">&lt;operation&gt; [n]&gt; /dev/null [options]</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/syntax.text\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-syntax-text\\">syntax.text</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+</div>
+</body></html>",
+}
+`;
+
 exports[`gatsby-remark-embedded-gist inline username overrides configuration with file in query with single line highlighted 1`] = `
 Object {
   "position": Position {
@@ -3067,6 +4508,131 @@ Object {
         <td id=\\"file-example-sh-L23\\" class=\\"blob-num js-line-number\\" data-line-number=\\"23\\"></td>
         <td id=\\"file-example-sh-LC23\\" class=\\"blob-code blob-code-inner js-file-line\\">$ unlink unexisting-file.sh <span class=\\"pl-k\\">&amp;</span><span class=\\"pl-k\\">&gt;</span> /dev/null</td>
       </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/example.sh\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-example-sh\\">example.sh</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-syntax-text\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-syntax-text-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-syntax-text-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">&lt;operation&gt; [n]&gt; /dev/null [options]</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/syntax.text\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-syntax-text\\">syntax.text</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+</div>
+</body></html>",
+}
+`;
+
+exports[`gatsby-remark-embedded-gist inline username overrides configuration with file in query with single line highlighted and single line selected 1`] = `
+Object {
+  "position": Position {
+    "end": Object {
+      "column": 90,
+      "line": 1,
+      "offset": 89,
+    },
+    "indent": Array [],
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "html",
+  "value": "<html><head></head><body><div id=\\"gist90436059\\" class=\\"gist\\">
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-2016-08-31-stream-redirection\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-text\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody><tr>
+        <td id=\\"file-2016-08-31-stream-redirection-L1\\" class=\\"blob-num js-line-number\\" data-line-number=\\"1\\"></td>
+        <td id=\\"file-2016-08-31-stream-redirection-LC1\\" class=\\"blob-code blob-code-inner js-file-line\\">2016.08.31.stream-redirection</td>
+      </tr>
+</tbody></table>
+
+
+  </div>
+
+  </div>
+</div>
+
+      </div>
+      <div class=\\"gist-meta\\">
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974/raw/83e7ad9d06525f3becfafb2f32ffa3122e8e846e/.2016.08.31.stream-redirection\\" style=\\"float:right\\">view raw</a>
+        <a href=\\"https://gist.github.com/weirdpattern/ce54fdb1e5621b5966e146026995b974#file-2016-08-31-stream-redirection\\">.2016.08.31.stream-redirection</a>
+        hosted with &#x2764; by <a href=\\"https://github.com\\">GitHub</a>
+      </div>
+    </div>
+    <div class=\\"gist-file\\">
+      <div class=\\"gist-data\\">
+        <div class=\\"js-gist-file-update-container js-task-list-container file-box\\">
+  <div id=\\"file-example-sh\\" class=\\"file\\">
+    
+
+  <div itemprop=\\"text\\" class=\\"blob-wrapper data type-shell\\">
+      <table class=\\"highlight tab-size js-file-line-container\\" data-tab-size=\\"8\\">
+      <tbody>
+      
+      
+      
+      <tr>
+        <td id=\\"file-example-sh-L5\\" class=\\"blob-num js-line-number\\" data-line-number=\\"5\\"></td>
+        <td id=\\"file-example-sh-LC5\\" class=\\"blob-code blob-code-inner js-file-line highlighted\\"><span class=\\"pl-c\\"><span class=\\"pl-c\\">#</span> redirects standard error (no error in this case)</span></td>
+      </tr>
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
 </tbody></table>
 
 

--- a/specs/index.specs.js
+++ b/specs/index.specs.js
@@ -83,6 +83,50 @@ describe("gatsby-remark-embedded-gist", () => {
     expect(getNodeContent(markdownAST)).toMatchSnapshot();
   });
 
+  it("generates an embedded gist with username and file in query with single line highlighted and single line selected", async () => {
+    const markdownAST = remark.parse(
+      "`gist:weirdpattern/ce54fdb1e5621b5966e146026995b974?file=example.sh&highlights=1&lines=1`"
+    );
+
+    const processed = await plugin({ markdownAST });
+    expect(processed).toBeTruthy();
+
+    expect(getNodeContent(markdownAST)).toMatchSnapshot();
+  });
+
+  it("generates an embedded gist with username and file in query with multiple lines highlighted and multiple lines selected", async () => {
+    const markdownAST = remark.parse(
+      "`gist:weirdpattern/ce54fdb1e5621b5966e146026995b974?file=example.sh&highlights=1,3,5&lines=1,2,3,5,6,7`"
+    );
+
+    const processed = await plugin({ markdownAST });
+    expect(processed).toBeTruthy();
+
+    expect(getNodeContent(markdownAST)).toMatchSnapshot();
+  });
+
+  it("generates an embedded gist with username and file in query with range of lines highlighted and selected", async () => {
+    const markdownAST = remark.parse(
+      "`gist:weirdpattern/ce54fdb1e5621b5966e146026995b974?file=example.sh&highlights=1-5&lines=1-6`"
+    );
+
+    const processed = await plugin({ markdownAST });
+    expect(processed).toBeTruthy();
+
+    expect(getNodeContent(markdownAST)).toMatchSnapshot();
+  });
+
+  it("generates an embedded gist with username and file in query with mixed lines highlighted and mixed lines selected", async () => {
+    const markdownAST = remark.parse(
+      "`gist:weirdpattern/ce54fdb1e5621b5966e146026995b974?file=example.sh&highlights=1-3,4,6&lines=1-6`"
+    );
+
+    const processed = await plugin({ markdownAST });
+    expect(processed).toBeTruthy();
+
+    expect(getNodeContent(markdownAST)).toMatchSnapshot();
+  });
+
   it("generates an embedded gist with default username", async () => {
     const markdownAST = remark.parse("`gist:ce54fdb1e5621b5966e146026995b974`");
 
@@ -179,6 +223,48 @@ describe("gatsby-remark-embedded-gist", () => {
     expect(getNodeContent(markdownAST)).toMatchSnapshot();
   });
 
+  it("generates an embedded gist with default username and file in query with muplie lines highlighted and multiple lines selected", async () => {
+    const markdownAST = remark.parse(
+      "`gist:ce54fdb1e5621b5966e146026995b974?file=example.sh&highlights=1,2,8&lines=1-5,8`"
+    );
+
+    const processed = await plugin(
+      { markdownAST },
+      { username: "weirdpattern" }
+    );
+    expect(processed).toBeTruthy();
+
+    expect(getNodeContent(markdownAST)).toMatchSnapshot();
+  });
+
+  it("generates an embedded gist with default username and file in query with range of lines highlighted and range of lines selected", async () => {
+    const markdownAST = remark.parse(
+      "`gist:ce54fdb1e5621b5966e146026995b974?file=example.sh&highlights=2-6&lines=2-7`"
+    );
+
+    const processed = await plugin(
+      { markdownAST },
+      { username: "weirdpattern" }
+    );
+    expect(processed).toBeTruthy();
+
+    expect(getNodeContent(markdownAST)).toMatchSnapshot();
+  });
+
+  it("generates an embedded gist with default username and file in query with mixed lines highlighted and selected", async () => {
+    const markdownAST = remark.parse(
+      "`gist:ce54fdb1e5621b5966e146026995b974?file=example.sh&highlights=2,8-10,12-14&lines=1-10,12-16`"
+    );
+
+    const processed = await plugin(
+      { markdownAST },
+      { username: "weirdpattern" }
+    );
+    expect(processed).toBeTruthy();
+
+    expect(getNodeContent(markdownAST)).toMatchSnapshot();
+  });
+
   it("inline username overrides configuration", async () => {
     const markdownAST = remark.parse(
       "`gist:weirdpattern/ce54fdb1e5621b5966e146026995b974`"
@@ -248,6 +334,50 @@ describe("gatsby-remark-embedded-gist", () => {
   it("inline username overrides configuration with file in query with mixed lines highlighted", async () => {
     const markdownAST = remark.parse(
       "`gist:weirdpattern/ce54fdb1e5621b5966e146026995b974?file=example.sh&highlights=1-3,5,10-13`"
+    );
+
+    const processed = await plugin({ markdownAST }, { username: "john" });
+    expect(processed).toBeTruthy();
+
+    expect(getNodeContent(markdownAST)).toMatchSnapshot();
+  });
+
+  it("inline username overrides configuration with file in query with single line highlighted and single line selected", async () => {
+    const markdownAST = remark.parse(
+      "`gist:weirdpattern/ce54fdb1e5621b5966e146026995b974?file=example.sh&highlights=5&lines=5`"
+    );
+
+    const processed = await plugin({ markdownAST }, { username: "john" });
+    expect(processed).toBeTruthy();
+
+    expect(getNodeContent(markdownAST)).toMatchSnapshot();
+  });
+
+  it("inline username overrides configuration with file in query with multiple lines highlighted and multiple lines selected", async () => {
+    const markdownAST = remark.parse(
+      "`gist:weirdpattern/ce54fdb1e5621b5966e146026995b974?file=example.sh&highlights=5,11&lines=1,5,6,10,11`"
+    );
+
+    const processed = await plugin({ markdownAST }, { username: "john" });
+    expect(processed).toBeTruthy();
+
+    expect(getNodeContent(markdownAST)).toMatchSnapshot();
+  });
+
+  it("inline username overrides configuration with file in query with range of lines highlighted and range of lines selected", async () => {
+    const markdownAST = remark.parse(
+      "`gist:weirdpattern/ce54fdb1e5621b5966e146026995b974?file=example.sh&highlights=5-10&lines=4-15`"
+    );
+
+    const processed = await plugin({ markdownAST }, { username: "john" });
+    expect(processed).toBeTruthy();
+
+    expect(getNodeContent(markdownAST)).toMatchSnapshot();
+  });
+
+  it("inline username overrides configuration with file in query with mixed lines highlighted and selected", async () => {
+    const markdownAST = remark.parse(
+      "`gist:weirdpattern/ce54fdb1e5621b5966e146026995b974?file=example.sh&highlights=1-3,5,10-13&lines=1-6,10,11,12,13`"
     );
 
     const processed = await plugin({ markdownAST }, { username: "john" });


### PR DESCRIPTION
Hey!

I was using this plug-in but needed the functionality to select specific lines so thought i'd share it back into the codebase.

It works by adding a `lines` parameter to the query string. e.g.

`gist:botoxparty/04f9c2bd909ba6f4424386d42242f961#serverless.yml?highlights=6,56&lines=1-4,50-60`

RE: Tests, it still passes but I think something has changed with the `isValid` check. What was the purpose of that function?

Do you have any time to write a test for this extended functionality?

Cheers!
Adam