### PR TITLE
fix: default options not properly merged

### DIFF
--- a/specs/gatsby-ssr.specs.js
+++ b/specs/gatsby-ssr.specs.js
@@ -8,53 +8,65 @@ describe("gatsby-ssr", () => {
   });
 
   it("executes when includeDefaultCss is default", () => {
-    onRenderBody({ setHeadComponents });
+    onRenderBody({ setHeadComponents }, { plugins: [] });
     expect(setHeadComponents).toHaveBeenCalledTimes(1);
   });
 
   it("executes when gistDefaultCssInclude is default", () => {
-    onRenderBody({ setHeadComponents });
+    onRenderBody({ setHeadComponents }, { plugins: [] });
     expect(setHeadComponents).toHaveBeenCalledTimes(1);
   });
 
   it("executes when includeDefaultCss is true", () => {
-    onRenderBody({ setHeadComponents }, { includeDefaultCss: true });
+    onRenderBody(
+      { setHeadComponents },
+      { plugins: [], includeDefaultCss: true }
+    );
     expect(setHeadComponents).toHaveBeenCalledTimes(1);
   });
 
   it("executes when gistDefaultCssInclude is true", () => {
-    onRenderBody({ setHeadComponents }, { gistDefaultCssInclude: true });
+    onRenderBody(
+      { setHeadComponents },
+      { plugins: [], gistDefaultCssInclude: true }
+    );
     expect(setHeadComponents).toHaveBeenCalledTimes(1);
   });
 
   it("doesn't execute when includeDefaultCss is false", () => {
-    onRenderBody({ setHeadComponents }, { includeDefaultCss: false });
+    onRenderBody(
+      { setHeadComponents },
+      { plugins: [], includeDefaultCss: false }
+    );
     expect(setHeadComponents).toHaveBeenCalledTimes(0);
   });
 
   it("doesn't execute when gistDefaultCssInclude is false", () => {
-    onRenderBody({ setHeadComponents }, { gistDefaultCssInclude: false });
+    onRenderBody(
+      { setHeadComponents },
+      { plugins: [], gistDefaultCssInclude: false }
+    );
     expect(setHeadComponents).toHaveBeenCalledTimes(0);
   });
 
   it("executes when gistCssPreload is missing", () => {
-    onRenderBody({ setHeadComponents });
+    onRenderBody({ setHeadComponents }, { plugins: [] });
     expect(setHeadComponents).toHaveBeenCalledTimes(1);
   });
 
   it("executes when gistCssPreload is false", () => {
-    onRenderBody({ setHeadComponents }, { gistCssPreload: false });
+    onRenderBody({ setHeadComponents }, { plugins: [], gistCssPreload: false });
     expect(setHeadComponents).toHaveBeenCalledTimes(1);
   });
 
   it("executes when gistCssPreload is true", () => {
-    onRenderBody({ setHeadComponents }, { gistCssPreload: true });
+    onRenderBody({ setHeadComponents }, { plugins: [], gistCssPreload: true });
     expect(setHeadComponents).toHaveBeenCalledTimes(1);
     expect(setHeadComponents.mock.calls[0][0].length).toBe(3);
   });
 
   it("executes when gistCssPreload is true", () => {
-    onRenderBody({ setHeadComponents }, { gistCssPreload: true });
+    onRenderBody({ setHeadComponents }, { plugins: [], gistCssPreload: true });
     expect(setHeadComponents).toHaveBeenCalledTimes(1);
     expect(setHeadComponents.mock.calls[0][0].length).toBe(3);
   });
@@ -62,7 +74,7 @@ describe("gatsby-ssr", () => {
   it("updates the url when one is provided", () => {
     onRenderBody(
       { setHeadComponents },
-      { gistCssPreload: true, gistCssUrlAddress: "https://test" }
+      { plugins: [], gistCssPreload: true, gistCssUrlAddress: "https://test" }
     );
     expect(setHeadComponents).toHaveBeenCalledTimes(1);
 

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -12,14 +12,16 @@ import React from "react";
  * @param {PluginOptions} options the options of the plugin.
  * @returns {*} rendered body.
  */
-export function onRenderBody(
-  { setHeadComponents },
+export function onRenderBody({ setHeadComponents }, options = {}) {
   options = {
-    gistCssPreload: false,
-    gistCssUrlAddress:
-      "https://github.githubassets.com/assets/gist-embed-b3b573358bfc66d89e1e95dbf8319c09.css"
-  }
-) {
+    ...{
+      gistCssPreload: false,
+      gistCssUrlAddress:
+        "https://github.githubassets.com/assets/gist-embed-b3b573358bfc66d89e1e95dbf8319c09.css"
+    },
+    ...options
+  };
+
   let includeCss = true;
   if (options.gistDefaultCssInclude != null) {
     includeCss = options.gistDefaultCssInclude;
@@ -54,7 +56,7 @@ export function onRenderBody(
               }}
             ></script>
           ]
-        : [<link href={options.gistCssUrlAddress} rel="stylesheet" />]
+        : [<link href={options.gistCssUrlAddress} key={key} rel="stylesheet" />]
     );
   }
 }


### PR DESCRIPTION
This PR fixes `options` being always `{}` and resulted in `gistCssUrlAddress` got empty since `undefined` is never passed to `options` but instead `{ plugins: [] }` in default. Also, `key` prop is added to `link` so it does not emit any errors from Gatsby.